### PR TITLE
Build Process Improvements - added silent option that gets rid of all std output messages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ usage_help() {
 -m <build model>
 -v <version number>
 -V <verbose>
+-s <silent output>
 -c <version code>
 -p <skip custom patch>
 -o <dist name>
@@ -27,7 +28,7 @@ usage_help() {
 do_run() {
 	local exit_code=0
 
-	if [ "$VERBOSE" = "1" ]; then
+	if [ "$SILENT" = "0" ]; then
 		$*
 		exit_code=$?
 	else
@@ -196,9 +197,9 @@ build_model_firmware() {
 	do_run make -C "$OPENWRT_DIR" defconfig
 
 	if [ "$VERBOSE" == "1" ]; then
-		make -C "$OPENWRT_DIR" -j8 V=99
+		do_run make -C "$OPENWRT_DIR" -j8 V=99
 	else
-		make -C "$OPENWRT_DIR" -j8
+		do_run make -C "$OPENWRT_DIR" -j8
 	fi
 }
 
@@ -262,6 +263,7 @@ while getopts m:v:c:o:AKdpCDXVh OPT; do
 		A) ALL_PACKAGES=1 ;;
 		K) ALL_KMODS=1 ;;
 		V) VERBOSE=1;;
+		s) SILENT=1;;
 		h) usage_help 0 ;;
 		*) usage_help 1 ;;
 	esac
@@ -281,6 +283,7 @@ fi
 [ -z "$OPENWRT_DIR" ] && OPENWRT_DIR="$ROOT_DIR/openwrt"
 [ -z "$OPENWRT_TAG" ] && OPENWRT_TAG="v22.03.3"
 [ -z "$VERBOSE" ] && VERBOSE=0
+[ -z "$SILENT" ] && SILENT=0
 OEM_DIR="$ROOT_DIR/$OEM"
 
 # validate OEM dir path

--- a/build.sh
+++ b/build.sh
@@ -249,7 +249,7 @@ build_firmware() {
 	copy_model_firmware "$build_model" || exit 1
 }
 
-while getopts m:v:c:o:AKdpCDXVh OPT; do
+while getopts m:v:c:o:AKdpCDXVsh OPT; do
 	case $OPT in
 		m) MODELS=$OPTARG ;;
 		v) VERSION=$OPTARG ;;

--- a/profile
+++ b/profile
@@ -7,3 +7,4 @@ GIT_OPENWRT="https://github.com/openwrt/openwrt"
 OEM=onion
 DEV_CLEAN_SKIP=1
 VERBOSE=0
+SILENT=0


### PR DESCRIPTION
@jempatel I've added a silent option that triggers the pipe to `/dev/null` in the `do_run` function.
I like the idea of being able to control the verbosity of the compile command as well as the output of any command run through `do_run`

Let me know what you think