### PR TITLE
fix: [12] use system's python binary path

### DIFF
--- a/.terraform/pipeline/modules/codebuild/main.tf
+++ b/.terraform/pipeline/modules/codebuild/main.tf
@@ -29,7 +29,7 @@ resource "aws_codebuild_project" "step_build_project" {
 
   environment {
     compute_type    = var.compute_type
-    image           = "aws/codebuild/standard:5.0"
+    image           = "aws/codebuild/standard:7.0"
     type            = "LINUX_CONTAINER"
     privileged_mode = var.is_privileged_mode
     dynamic "environment_variable" {

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,14 +7,13 @@ env:
     ROOT_PATH: "/openwrt"
 phases:
   install:
-    runtime-versions:
-      python: 3.8
     commands:
       - echo "Installing dependencies"
       - apt-get update
-      - apt-get -y install --upgrade awscli
-      - apt update
-      - apt -y install build-essential clang flex bison g++ gawk gcc-multilib g++-multilib gettext git libncurses5-dev libssl-dev python3-distutils rsync unzip zlib1g-dev file wget
+      - apt -y install build-essential clang flex bison g++ gawk gcc-multilib g++-multilib gettext git libncurses5-dev libssl-dev python3-distutils rsync unzip zlib1g-dev file wget python3
+      - apt -y install --upgrade awscli
+      # remove pyenv from path to use the default system installation.
+      - export PATH=$(echo $PATH | sed 's@/root/.pyenv/shims:/root/.pyenv/bin:@@g')
   pre_build:
     commands:
       - mkdir -p $ROOT_PATH


### PR DESCRIPTION
- Codebuild is using pyenv to manage python versions: 
- The solutions available are:
1. creating a custom image
2. change the path in runtime (adopted)

-> Creating a custom image means building and maintaining security patches for the image, changing the Path in runtime was the chosen solution for this. 

Code build is now using ubuntu22.04